### PR TITLE
fix error - wont run if no extra arguements given

### DIFF
--- a/Windows/AD GPO Powershell Installer (WIN).ps1
+++ b/Windows/AD GPO Powershell Installer (WIN).ps1
@@ -29,7 +29,7 @@ $Global:mcsagent = Get-Service -name "Sophos MCS Agent" -ea SilentlyContinue
 }
 
 # Sophos Central Installation
-Start-Transcript c:\temp\SophosCentralInstallLog.txt
+Start-Transcript $env:systemdrive\temp\SophosCentralInstallLog.txt
 Write-Host "Starting the Sophos Central Installation based on the variables defined in the site"
 Write-Host ""
 Write-Host "Checking to see if Sophos is Already Installed"

--- a/Windows/AD GPO Powershell Installer (WIN).ps1
+++ b/Windows/AD GPO Powershell Installer (WIN).ps1
@@ -80,7 +80,12 @@ Write-Host "From: "$InstallerLocation""
 Write-Host ""
 Write-Host "With extra options: "$InstallerArguments""
 
-start-process $InstallerLocation --quiet $InstallerArguments
+if ($InstallerArguments -eq "") {
+	start-process $InstallerLocation --quiet
+}
+else {
+	start-process $InstallerLocation --quiet $InstallerArguments
+}
 
 $timeout = new-timespan -Minutes 30
 $install = [diagnostics.stopwatch]::StartNew()


### PR DESCRIPTION
if no $InstallerArguements are given, it fails to run. this checks for an empty string and then omits the variable if empty to fix.